### PR TITLE
gopro2json: use encoding/json to encode telemetry data

### DIFF
--- a/bin/gopro2json/gopro2json.go
+++ b/bin/gopro2json/gopro2json.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/stilldavid/gopro-utils/telemetry"
 )
+
+type data struct {
+	Data []telemetry.TELEM_OUT `json:"data"`
+}
 
 func main() {
 	inName := flag.String("i", "", "Required: telemetry file to read")
@@ -23,42 +29,19 @@ func main() {
 		fmt.Printf("Cannot access telemetry file %s.\n", *inName)
 		os.Exit(1)
 	}
+	defer telemFile.Close()
 
-	jsonFile, err := os.Create(*outName)
-	if err != nil {
-		fmt.Printf("Cannot make output file %s.\n", *outName)
-		os.Exit(1)
-	}
-
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			fmt.Printf("Cannot close file %s: %s", file.Name(), err)
-			os.Exit(1)
-		}
-	}(telemFile)
-
-	defer func(file *os.File) {
-		err := file.Close()
-		if err != nil {
-			fmt.Printf("Cannot close file %s: %s", file.Name(), err)
-			os.Exit(1)
-		}
-	}(jsonFile)
-
-	jsonFile.WriteString(`{"data":[`)
+	var d data
 
 	t := &telemetry.TELEM{}
 	t_prev := &telemetry.TELEM{}
-	first := true
 
 	for {
 		t, err = telemetry.Read(telemFile)
-		if err != nil {
-			fmt.Println(err)
+		if err != nil && err != io.EOF {
+			fmt.Println("Error reading telemetry file", err)
 			os.Exit(1)
-		}
-		if t == nil {
+		} else if err == io.EOF || t == nil {
 			break
 		}
 
@@ -72,16 +55,29 @@ func main() {
 		// process until t.Time
 		t_prev.Process(t.Time.Time)
 
-		buf, _ := t_prev.ShitJson(first)
-		jsonFile.WriteString(buf.String())
-		if first {
-			first = false
-		}
+		telems := t_prev.ShitJson()
+		d.Data = append(d.Data, telems...)
 
 		*t_prev = *t
 		t = &telemetry.TELEM{}
 	}
 
-	// end the bogusness
-	jsonFile.WriteString(`]}`)
+	jsonFile, err := os.Create(*outName)
+	if err != nil {
+		fmt.Printf("Cannot make output file %s.\n", *outName)
+		os.Exit(1)
+	}
+
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			fmt.Printf("Cannot close json file %s: %s", file.Name(), err)
+			os.Exit(1)
+		}
+	}(jsonFile)
+
+	if err := json.NewEncoder(jsonFile).Encode(d); err != nil {
+		fmt.Println("Error encoding output json", err)
+		os.Exit(1)
+	}
 }

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,9 +1,6 @@
 package telemetry
 
 import (
-	"bytes"
-	"encoding/json"
-	"errors"
 	"time"
 
 	"github.com/paulmach/go.geo"
@@ -64,15 +61,10 @@ func (t *TELEM) Process(until time.Time) error {
 	return nil
 }
 
-func (t *TELEM) ShitJson(first bool) (bytes.Buffer, error) {
-	var buffer bytes.Buffer
+func (t *TELEM) ShitJson() []TELEM_OUT {
+	var out []TELEM_OUT
 
 	for i, tp := range t.Gps {
-		if first && i == 0 {
-		} else {
-			buffer.Write([]byte(","))
-		}
-
 		jobj := TELEM_OUT{&tp, 0, 0, 0, 0}
 		if 0 == i {
 			jobj.GpsAccuracy = t.GpsAccuracy.Accuracy
@@ -94,14 +86,8 @@ func (t *TELEM) ShitJson(first bool) (bytes.Buffer, error) {
 			jobj.Heading = last_good_heading
 		}
 
-		jstr, err := json.Marshal(jobj)
-		if err != nil {
-			return buffer, errors.New("error jsoning\n")
-		}
-
-		buffer.Write(jstr)
-
+		out = append(out, jobj)
 	}
 
-	return buffer, nil
+	return out
 }


### PR DESCRIPTION
This PR utilizes Go's builtin json encoding to output the resulting `data` json so the program doesn't have to put it together itself. 

Other changes:

- No need to check error on closing a read-only file
- Check for `io.EOF` and break in the for loop instead of exiting the program