### PR TITLE
Fix GPXPoint Timestamp nanosecond parameter

### DIFF
--- a/bin/gopro2gpx/gopro2gpx.go
+++ b/bin/gopro2gpx/gopro2gpx.go
@@ -64,7 +64,7 @@ func main() {
 						Longitude: telems[i].Longitude,
 						Elevation: *gpx.NewNullableFloat64(telems[i].Altitude),
 					},
-					Timestamp: time.Unix(telems[i].TS/1000/1000, telems[i].TS%(1000*1000)),
+					Timestamp: time.Unix(telems[i].TS/1000/1000, telems[i].TS%(1000*1000)*1000),
 				},
 			)
 		}


### PR DESCRIPTION
According to [time.Unix](https://golang.org/pkg/time/#Unix), the second parameter should be nanoseconds, but here only convert to microseconds, which lead the wrong result.

Multiply 1000 should solve this problem.