### PR TITLE
Fix GoPro6 firmware v2.01 issue

### DIFF
--- a/telemetry/reader.go
+++ b/telemetry/reader.go
@@ -47,6 +47,9 @@ func Read(f io.Reader) (*TELEM, error) {
 		"WRGB",
 		"MAGN",
 		"ALLD",
+		"MTRX",
+		"ORIN",
+		"ORIO"
 	}
 
 	label := make([]byte, 4, 4) // 4 byte ascii label of data

--- a/telemetry/reader.go
+++ b/telemetry/reader.go
@@ -49,7 +49,7 @@ func Read(f io.Reader) (*TELEM, error) {
 		"ALLD",
 		"MTRX",
 		"ORIN",
-		"ORIO"
+		"ORIO",
 	}
 
 	label := make([]byte, 4, 4) // 4 byte ascii label of data


### PR DESCRIPTION
Add new labels(MTRX, ORIN, ORIO) in GoPro6 firmware v2.01 for solving #17 issue