### PR TITLE
Updated UTC time conversion

### DIFF
--- a/bin/gopro2gpx/gopro2gpx.go
+++ b/bin/gopro2gpx/gopro2gpx.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"time"
 
@@ -57,6 +58,9 @@ func main() {
 		telems := t_prev.ShitJson()
 
 		for i, _ := range telems {
+			secs := int64(math.Floor(telems[i].TS))
+			// get the decimal part of the timestamp as an integer (representing nanoseconds)
+			nsecs := int64((telems[i].TS * 1000) - (math.Floor(telems[i].TS) * 1000)) * int64(time.Millisecond)
 			segment.AppendPoint(
 				&gpx.GPXPoint{
 					Point: gpx.Point{
@@ -64,7 +68,7 @@ func main() {
 						Longitude: telems[i].Longitude,
 						Elevation: *gpx.NewNullableFloat64(telems[i].Altitude),
 					},
-					Timestamp: time.Unix(telems[i].TS/1000/1000, telems[i].TS%(1000*1000)*1000),
+					Timestamp: time.Unix(secs, nsecs),
 				},
 			)
 		}

--- a/telemetry/gps5.go
+++ b/telemetry/gps5.go
@@ -12,7 +12,7 @@ type GPS5 struct {
 	Altitude  float64 `json:"alt"`    // meters above wgs84 ellipsoid ?
 	Speed     float64 `json:"spd"`    // m/s
 	Speed3D   float64 `json:"spd_3d"` // m/s, standard error?
-	TS        int64   `json:"utc"`
+	TS        float64 `json:"utc"`
 }
 
 func (gps *GPS5) Parse(bytes []byte, scale *SCAL) error {

--- a/telemetry/gpsu.go
+++ b/telemetry/gpsu.go
@@ -15,7 +15,7 @@ func (gpsu *GPSU) Parse(bytes []byte) error {
 		return errors.New("Invalid length GPSU packet")
 	}
 
-	t, err := time.Parse("060102150405", string(bytes))
+	t, err := time.Parse("060102150405.000", string(bytes))
 	if err != nil {
 		return err
 	}

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -55,7 +55,7 @@ func (t *TELEM) FillTimes(until time.Time) error {
 	for i, _ := range t.Gps {
 		dur := time.Duration(float64(i)*offset*1000) * time.Millisecond
 		ts := t.Time.Time.Add(dur)
-		t.Gps[i].TS = ts.UnixNano() / 1000
+		t.Gps[i].TS = ts.UnixNano() / int64(time.Millisecond)
 	}
 
 	return nil

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -55,7 +55,7 @@ func (t *TELEM) FillTimes(until time.Time) error {
 	for i, _ := range t.Gps {
 		dur := time.Duration(float64(i)*offset*1000) * time.Millisecond
 		ts := t.Time.Time.Add(dur)
-		t.Gps[i].TS = ts.UnixNano() / int64(time.Millisecond)
+		t.Gps[i].TS = ts.UnixNano() / float64(time.Second)
 	}
 
 	return nil

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -1,6 +1,7 @@
 package telemetry
 
 import (
+	"math"
 	"time"
 
 	"github.com/paulmach/go.geo"
@@ -55,7 +56,8 @@ func (t *TELEM) FillTimes(until time.Time) error {
 	for i, _ := range t.Gps {
 		dur := time.Duration(float64(i)*offset*1000) * time.Millisecond
 		ts := t.Time.Time.Add(dur)
-		t.Gps[i].TS = ts.UnixNano() / float64(time.Second)
+		pre_round := float64(ts.UnixNano()) / float64(time.Second)
+		t.Gps[i].TS = math.Round(pre_round / .001) * .001
 	}
 
 	return nil


### PR DESCRIPTION
I updated `gpsu.go` to include the milliseconds in the format string―it doesn't change functionality, but I thought it made it a little more clear as to what the input data actually looked like (I believe the format is `yymmddhhmmss.sss` as per [gpmf-parser's README](https://github.com/gopro/gpmf-parser)).

The change in `telemetry.go` makes it so that the UTC timestamps produced by `gopro2json` don't have an extra 3 `0`'s at the end of them, as mentioned in [my comment](https://github.com/stilldavid/gopro-utils/issues/33#issuecomment-488759013) in #33. Also, the 3 digits before the trailing zeros (corresponding to milliseconds) are now after the decimal. With this change, the JSON UTC timestamps are valid Unix timestamps. The 3 digits after the decimal place are milliseconds.

Please let me know if there are any changes you'd like me to make...thanks!